### PR TITLE
Enable custom hostname

### DIFF
--- a/scripts/libs/env.js
+++ b/scripts/libs/env.js
@@ -49,6 +49,10 @@ module.exports = {
 		var packageJson = this.packageJson();
 		return this.arg('port') || packageJson.config.port || default_;
 	},
+	host: function(default_ = '::1') {
+		var packageJson = this.packageJson();
+		return this.arg('host') || packageJson.config.host || default_;
+	},
 	project: function() {
 		if(this.arg('project')) {
 			this._project = this.arg('project');

--- a/scripts/libs/serve.js
+++ b/scripts/libs/serve.js
@@ -10,7 +10,7 @@ class Serve extends Builder {
     var args = [
       'serve',
       `--port=${env.port()}`,
-      '--host=::1',
+      `--host=${env.host() || '::1'}`,
       '--disable-host-check',
       `--live-reload=${env.liveReload()}`,
       `--proxy-config=proxies/${this.configuration}.conf.json`,

--- a/scripts/libs/serve.js
+++ b/scripts/libs/serve.js
@@ -10,7 +10,7 @@ class Serve extends Builder {
     var args = [
       'serve',
       `--port=${env.port()}`,
-      `--host=${env.host() || '::1'}`,
+      `--host=${env.host()}`,
       '--disable-host-check',
       `--live-reload=${env.liveReload()}`,
       `--proxy-config=proxies/${this.configuration}.conf.json`,


### PR DESCRIPTION
Just so we can pass the config for the hostname from the package.json config object up to the Serve object. The default `::1` might serve most cases, but you could want to run this under a different hostname. 

Feel free to ignore this PR if it doesn't serve you, but since I needed to make that change, I thought of passing it back to you as well. 

TODO: Also enable custom certificate params to go along with the `secure` option when using custom domains.